### PR TITLE
Add require statement to Usage section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ So keep sure you have installed and used it.
 # Usage
 
 ```javascript
+const {BaseHrefWebpackPlugin} = require('base-href-webpack-plugin')
+//...
 plugins: [
   new BaseHrefWebpackPlugin({
     baseHref: '/'


### PR DESCRIPTION
Took some time to figure out that `BaseHrefWebpackPlugin` is a named export.