### PR TITLE
Fix/update typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,11 +1,11 @@
 declare module 'base-href-webpack-plugin' {
+  import { Plugin } from 'webpack';
+
   interface BaseHrefWebpackPluginOptions {
     baseHref?: string
   }
 
-  class BaseHrefWebpackPlugin {
+  class BaseHrefWebpackPlugin extends Plugin {
     constructor(options: BaseHrefWebpackPluginOptions);
-
-    apply(compiler: any);
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "author": "Rokas Brazdzionis <rokas.brazdzionis@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
+    "@types/webpack": "^4.4.24",
     "html-webpack-plugin": "^3.0.0",
     "webpack": "^4.0.0"
   },


### PR DESCRIPTION
Current typings for the package cause error as they don't specify return type of `apply` method.

They also do not use original Webpack types available in `@types/webpack` package.

This change brings Webpack types to the mix and replaces custom `apply` method declaration with the official one.